### PR TITLE
Make it possible to flakeify files with various extensions

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -28,6 +28,9 @@ def pytest_addoption(parser):
     parser.addini(
         "flake8-max-line-length",
         help="maximum line length")
+    parser.addini(
+        "flake8-extensions", type="args", default=[".py"],
+        help="a list of file extensions, for example: .py .pyx")
 
 
 def pytest_configure(config):
@@ -35,13 +38,14 @@ def pytest_configure(config):
     if config.option.flake8:
         config._flake8ignore = Ignorer(config.getini("flake8-ignore"))
         config._flake8maxlen = config.getini("flake8-max-line-length")
+        config._flake8exts = config.getini("flake8-extensions")
         config._flake8mtimes = config.cache.get(HISTKEY, {})
 
 
 def pytest_collect_file(path, parent):
     """Filter files down to which ones should be checked."""
     config = parent.config
-    if config.option.flake8 and path.ext == '.py':
+    if config.option.flake8 and path.ext in config._flake8exts:
         flake8ignore = config._flake8ignore(path)
         if flake8ignore is not None:
             return Flake8Item(path, parent, flake8ignore, config._flake8maxlen)

--- a/test_flake8.py
+++ b/test_flake8.py
@@ -87,6 +87,22 @@ class TestIgnores:
         ])
 
 
+def test_extensions(testdir):
+    testdir.makeini("""
+        [pytest]
+        flake8-extensions = .py .pyx
+    """)
+    testdir.makefile(".pyx", """
+        @cfunc
+        def f():
+            pass
+    """)
+    result = testdir.runpytest("--flake8")
+    result.stdout.fnmatch_lines([
+        "*collected 1*",
+    ])
+
+
 def test_ok_verbose(testdir):
     p = testdir.makepyfile("""
         class AClass:


### PR DESCRIPTION
Added a new option to specify extensions of files that should be scanned. For example: `flake8-extensions: .py .pyx`. This is useful to scan "[pure](https://github.com/cython/cython/wiki/pure)" Cython files (usually .pyx).

Combined with replacing `cdefs` with decorators (`@cclass`, `@cfunc`, `@locals` etc.; or there is also an annotation syntax), and ignoring E901 (mostly due to `cimport`; the code is statically compiled, so syntax errors will be detected anyhow), that's almost a linting solution for Cython.