### PR TITLE
Pin flake8 dependency to <3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'pytest11': ['flake8 = pytest_flake8'],
     },
     install_requires=[
-        'flake8>=2.5',
+        'flake8>=2.5,<3.0.0',
         'pytest>=2.8',
     ],
 )


### PR DESCRIPTION
Flake8 3.0.0b1 was released on PyPI and this change prevents an issue when
using pytest-flake8 in the test_requires list of a setup.py. The list will
be installed by setuptools which doesn't have a concept of not installing
pre-release unless specified explicitly.