### PR TITLE
Limit flake8 to 2.5 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'pytest11': ['flake8 = pytest_flake8'],
     },
     install_requires=[
-        'flake8>=2.5',
+        'flake8>=2.5,<3.0a0',
         'pytest>=2.8',
     ],
 )


### PR DESCRIPTION
The newly released flake8 3.0.0 release broke the plugin.