### PR TITLE
Potential fix for issue #8

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -180,7 +180,7 @@ def check_file(path, flake8ignore, maxlength, maxcomplexity,
     app.find_plugins()
     app.register_plugin_options()
     app.parse_configuration_and_cli(args)
-    app.options.ignore = flake8ignore
+    app.options.ignore.extend(flake8ignore)
     app.make_formatter()  # fix this
     app.make_notifier()
     app.make_guide()


### PR DESCRIPTION
Ignore options are properly loaded from ``setup.cfg`` but then overwritten.  Here we simply extend this list.

I do not understand the reason for giving `pytest-flake8` its own options (why not just allow `flake8` to read them from the standard places) so I have not attempted to modify any of the other code.  See also the discussion in issue #8.