### PR TITLE
Add pytest marker for flake8

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -51,6 +51,7 @@ def pytest_configure(config):
         config._flake8showshource = config.getini("flake8-show-source")
         config._flake8statistics = config.getini("flake8-statistics")
         config._flake8exts = config.getini("flake8-extensions")
+        config.addinivalue_line('markers', "flake8: Tests which run flake8.")
         if hasattr(config, 'cache'):
             config._flake8mtimes = config.cache.get(HISTKEY, {})
 


### PR DESCRIPTION
This is required for compatibility with pytest --strict mode when using
pytest>=3.1 as discussed in https://github.com/pytest-dev/pytest/issues/2455

Tested working on my machine.

Fixes https://github.com/tholo/pytest-flake8/issues/23