### PR TITLE
Allow for cache based on file hash

### DIFF
--- a/test_flake8.py
+++ b/test_flake8.py
@@ -114,6 +114,37 @@ class TestIgnores:
             "*2 passed*",
         ])
 
+    def test_hash_caching_sha1(self, testdir, example):
+        testdir.tmpdir.ensure("hello.py")
+        testdir.makeini("""
+            [pytest]
+            flake8-cache = hash
+            flake8-hash-algo = sha1
+        """)
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            # "*plugins*flake8*",
+            "*W293*",
+            "*W292*",
+            "*1 failed*",
+        ])
+        assert result.ret != 0
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            "*W293*",
+            "*W292*",
+            "*1 failed*",
+        ])
+        testdir.makeini("""
+            [pytest]
+            flake8-ignore = *.py W293 W292
+            flake8-cache = hash
+        """)
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            "*2 passed*",
+        ])
+
 
 def test_extensions(testdir):
     testdir.makeini("""

--- a/test_flake8.py
+++ b/test_flake8.py
@@ -87,6 +87,36 @@ class TestIgnores:
             "*2 passed*",
         ])
 
+    def test_hash_caching(self, testdir, example):
+        testdir.tmpdir.ensure("hello.py")
+        testdir.makeini("""
+            [pytest]
+            flake8-cache = hash
+        """)
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            # "*plugins*flake8*",
+            "*W293*",
+            "*W292*",
+            "*1 failed*",
+        ])
+        assert result.ret != 0
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            "*W293*",
+            "*W292*",
+            "*1 failed*",
+        ])
+        testdir.makeini("""
+            [pytest]
+            flake8-ignore = *.py W293 W292
+            flake8-cache = hash
+        """)
+        result = testdir.runpytest("--flake8", )
+        result.stdout.fnmatch_lines([
+            "*2 passed*",
+        ])
+
 
 def test_extensions(testdir):
     testdir.makeini("""


### PR DESCRIPTION
I transitioned one of my projects from a local Jenkins server to Travis-CI.  Due to the way Travis loads the test environment the mtimes of all the files were changed.  This solution allows for the use of hashes based on the file's content which isn't changed between unit test runs.

My goal is to allow both mtimes and hashes and to default to mtimes since it is faster than hashes.