### PR TITLE
Set WARN level by default for flake8 calls

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -1,5 +1,6 @@
 """py.test plugin to test with flake8."""
 
+import logging
 import os
 import re
 
@@ -180,6 +181,9 @@ def check_file(path, flake8ignore, maxlength, maxcomplexity,
         args += ['--show-source']
     if statistics:
         args += ['--statistics']
+
+    logging.getLogger('flake8').setLevel(logging.WARN)
+
     app = application.Application()
     app.parse_preliminary_options_and_args(args)
     app.make_config_finder()


### PR DESCRIPTION
With this patch `pytest-flake8` will produce following clean output:

```python
__________________________________________________________________________________ FLAKE8-check __________________________________________________________________________________
/Users/eirnym/Development/test/xxx/test_xxx.py:2:16: E261 at least two spaces before inline comment
/Users/eirnym/Development/test/xxx/test_xxx.py:2:16: E262 inline comment should start with '# '

======================================================================= 1 failed, 1 passed in 0.39 seconds =======================================================================
```