### PR TITLE
Limit flake8 to a single job per test

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -178,6 +178,8 @@ def check_file(path, flake8ignore, maxlength, maxcomplexity,
         args += ['--show-source']
     if statistics:
         args += ['--statistics']
+    # One file per flake8 call so limit flake8 to one job
+    args += ['--jobs', "1"]
     app = application.Application()
     app.parse_preliminary_options_and_args(args)
     app.make_config_finder()


### PR DESCRIPTION
Without this change flake8 creates many subprocesses every time
it is invoked. This causes significant overhead and slows down
test execution. In conjunction with pytest-xdist many hundreds
of additional flake8 processes can be created which causes
significant load issues.