### PR TITLE
Implement collect() for Flake8Item

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -145,6 +145,9 @@ class Flake8Item(pytest.Item, pytest.File):
             ignores = ""
         return (self.fspath, -1, "FLAKE8-check%s" % ignores)
 
+    def collect(self):
+        return iter((self,))
+
 
 class Ignorer:
     def __init__(self, ignorelines, coderex=re.compile(r"[EW]\d\d\d")):

--- a/test_flake8.py
+++ b/test_flake8.py
@@ -153,6 +153,12 @@ def test_keyword_match(testdir):
     result.assert_outcomes(failed=1)
 
 
+def test_run_on_init_file(testdir):
+    d = testdir.mkpydir("tests")
+    result = testdir.runpytest("--flake8", d / "__init__.py")
+    result.assert_outcomes(passed=1)
+
+
 @pytest.mark.xfail("sys.platform == 'win32'")
 def test_unicode_error(testdir):
     x = testdir.tmpdir.join("x.py")


### PR DESCRIPTION
Solves NotImplementedError on python3.8 pytest 6.1 when run on an ``__init__.py`` file:

```
Traceback (most recent call last):
  File "venv/lib/python3.8/site-packages/_pytest/runner.py", line 310, in from_call
    result = func()  # type: Optional[TResult]
  File "venv/lib/python3.8/site-packages/_pytest/runner.py", line 340, in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
  File "venv/lib/python3.8/site-packages/_pytest/nodes.py", line 463, in collect
    raise NotImplementedError("abstract")
NotImplementedError: abstract
```

Copied from: https://github.com/shopkeep/pytest-black/pull/47

Modified to return iterator to support python2.7