### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: pypy2.7-6.0
       env: TOXENV=pypy
     - python: pypy3.5-6.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py36-pytesttrunk,py36-xdist,py34,py35,py36,py37,py38,pypy,pypy3
+envlist=py27,py36-pytesttrunk,py36-xdist,py34,py35,py36,py37,py38,py39,pypy,pypy3
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Would you consider dropping support for Python versions after EOL (2.7, 3.4, 3.5)?