### PR TITLE
Get cache from disk to avoid cache overwriting.

### DIFF
--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -80,8 +80,10 @@ def pytest_collect_file(file_path, path, parent):
 
 def pytest_unconfigure(config):
     """Flush cache at end of run."""
-    if hasattr(config, "_flake8mtimes"):
-        config.cache.set(HISTKEY, config._flake8mtimes)
+    if hasattr(config, "_flake8mtimes") and config._flake8mtimes:
+        cache = config.cache.get(HISTKEY, {})
+        cache.update(config._flake8mtimes)
+        config.cache.set(HISTKEY, cache)
 
 
 class Flake8Error(Exception):


### PR DESCRIPTION
Fix #94.

The cache is always written to the same file, for each worker and for the controller.

Controller don't execute tests and never has cache. Each worker has part of the cache, so they must get current cache to update it instead of just write to it.

It's still possible to some overwrite happen because workers don´t have a global lock. The pytest-xdist [suggests to use `filelock`](https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once) to solve this problem, but it is an external dependency.